### PR TITLE
Type traits for iterables

### DIFF
--- a/mozart++/mpp_core/type_traits.hpp
+++ b/mozart++/mpp_core/type_traits.hpp
@@ -47,9 +47,6 @@ namespace mpp_impl {
 }
 
 namespace mpp {
-    template <typename ...>
-    using void_t = void;
-
     struct true_type {
         constexpr static bool value = true;
     };
@@ -57,6 +54,28 @@ namespace mpp {
     struct false_type {
         constexpr static bool value = false;
     };
+
+    /*
+     * Something to simulate the requires keyword introduced in C++20.
+     */
+
+    template <typename ...>
+    using requires_all = void;
+
+    template <bool>
+    struct requires_true_ {
+    };
+
+    template <>
+    struct requires_true_<true> {
+        using type = void;
+    };
+
+    template <bool b>
+    using requires_true = typename requires_true_<b>::type;
+
+    template <typename T, typename R>
+    using requires_same = requires_true<std::is_same<T, R>::value>;
 
     /**
      * Integer Sequence
@@ -174,4 +193,22 @@ namespace mpp {
         template <typename SeqL, typename SeqR>
         static constexpr bool equals_v = equals<SeqL, SeqR>::value;
     };
+
+    template <typename, typename = mpp::requires_all<>>
+    struct is_iterable : mpp::false_type {};
+
+    template <typename T>
+    struct is_iterable<T,
+        mpp::requires_all<
+            typename T::iterator,
+            typename T::const_iterator,
+            requires_same<typename T::iterator, decltype(std::declval<T>().begin())>,
+            requires_same<typename T::iterator, decltype(std::declval<T>().end())>,
+            requires_same<typename T::const_iterator, decltype(std::declval<T>().cbegin())>,
+            requires_same<typename T::const_iterator, decltype(std::declval<T>().cend())>
+        >> : public mpp::true_type {
+    };
+
+    template <typename T>
+    static constexpr bool is_iterable_v = is_iterable<T>::value;
 }

--- a/mozart++/mpp_core/type_traits.hpp
+++ b/mozart++/mpp_core/type_traits.hpp
@@ -77,6 +77,9 @@ namespace mpp {
     template <typename T, typename R>
     using requires_same = requires_true<std::is_same<T, R>::value>;
 
+    template <typename T>
+    using remove_cr_t = std::remove_reference_t<std::remove_const_t<T>>;
+
     /**
      * Integer Sequence
      * usage: using seq = make_sequence_t<Maximum>;
@@ -210,5 +213,30 @@ namespace mpp {
     };
 
     template <typename T>
-    static constexpr bool is_iterable_v = is_iterable<T>::value;
+    static constexpr bool is_iterable_v = is_iterable<mpp::remove_cr_t<T>>::value;
+
+    template <typename, typename = void>
+    struct iterable_traits {};
+
+    template <typename Container>
+    struct iterable_traits<Container, std::enable_if_t<is_iterable_v<Container>>> {
+        using iterator_type = typename mpp::remove_cr_t<Container>::iterator;
+        using const_iterator_type = typename mpp::remove_cr_t<Container>::const_iterator;
+
+        static constexpr iterator_type begin(Container &&c) {
+            return c.begin();
+        }
+
+        static constexpr iterator_type end(Container &&c) {
+            return c.end();
+        }
+
+        static constexpr const_iterator_type cbegin(Container &&c) {
+            return c.cbegin();
+        }
+
+        static constexpr const_iterator_type cend(Container &&c) {
+            return c.cbegin();
+        }
+    };
 }

--- a/mozart++/mpp_core/type_traits.hpp
+++ b/mozart++/mpp_core/type_traits.hpp
@@ -198,7 +198,10 @@ namespace mpp {
     };
 
     template <typename, typename = mpp::requires_all<>>
-    struct is_iterable : mpp::false_type {};
+    struct is_iterable : public mpp::false_type {};
+
+    template <typename CharT>
+    struct is_iterable<std::basic_string<CharT>> : public mpp::false_type {};
 
     template <typename T>
     struct is_iterable<T,

--- a/tests/test-type_traits.cpp
+++ b/tests/test-type_traits.cpp
@@ -1,0 +1,26 @@
+/**
+ * Mozart++ Template Library
+ * Licensed under MIT License
+ * Copyright (c) 2020 Covariant Institute
+ * Website: https://covariant.cn/
+ * Github:  https://github.com/covariant-institute/
+ */
+
+#include <mozart++/core>
+#include <cstdio>
+
+#include <vector>
+#include <list>
+#include <deque>
+#include <unordered_map>
+
+int main() {
+    using namespace mpp;
+    static_assert(is_iterable_v<std::vector<int>>, "You wrote a bug");
+    static_assert(is_iterable_v<std::vector<std::vector<int>>>, "You wrote a bug");
+    static_assert(is_iterable_v<std::string>, "You wrote a bug");
+    static_assert(!is_iterable_v<int>, "You wrote a bug");
+    static_assert(!is_iterable_v<mpp::function<void()>>, "You wrote a bug");
+    static_assert(!is_iterable_v<mpp::function<const char *()>>, "You wrote a bug");
+    static_assert(!is_iterable_v<mpp::function<const char *()>>, "You wrote a bug");
+}

--- a/tests/test-type_traits.cpp
+++ b/tests/test-type_traits.cpp
@@ -18,7 +18,7 @@ int main() {
     using namespace mpp;
     static_assert(is_iterable_v<std::vector<int>>, "You wrote a bug");
     static_assert(is_iterable_v<std::vector<std::vector<int>>>, "You wrote a bug");
-    static_assert(is_iterable_v<std::string>, "You wrote a bug");
+    static_assert(!is_iterable_v<std::string>, "You wrote a bug");
     static_assert(!is_iterable_v<int>, "You wrote a bug");
     static_assert(!is_iterable_v<mpp::function<void()>>, "You wrote a bug");
     static_assert(!is_iterable_v<mpp::function<const char *()>>, "You wrote a bug");


### PR DESCRIPTION
Support iterable containers:

iterables are containers just like `std::vector`, `std::deque` or `std::unordered_map`:
1. has a typedef named `iterator`.
2. has a typedef named  `const_iterator`.
3. has `begin()`, `end()`, `cbegin()`, `cend()` methods.

